### PR TITLE
Update resuming-transfers.mdx with a typo fix

### DIFF
--- a/ren-js/how-to/resuming-transfers.mdx
+++ b/ren-js/how-to/resuming-transfers.mdx
@@ -13,7 +13,7 @@ import { DocTag, DocType } from "/components/DocTag";
 :::warning
 
 NOTE: Resuming a mint that is in progress requires the all of the parameters passed in to `lockAndMint` to be available. You should reconstruct the chain objects (`Ethereum`, `Bitcoin`, etc.) using the same values.
-If the parameters are lost, the funds may be unrecoverable, so it's important to use a reliable persistat storage if mint details need to be stored.
+If the parameters are lost, the funds may be unrecoverable, so it's important to use a reliable persistent storage if mint details need to be stored.
 
 :::
 


### PR DESCRIPTION
fixed a typo in the warning "persistent"