### PR TITLE
Update deployments.mdx

### DIFF
--- a/contracts/deployments.mdx
+++ b/contracts/deployments.mdx
@@ -352,16 +352,16 @@ Currently, they are EVM-based contracts and Solana programs.
     <ul style={{ listStyleType: "none", padding: 0 }}>
       <ContractItem
         name="GatewayRegistry"
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         address="0x21C482f153D0317fe85C60bE1F7fa079019fcEbD"
       />
       <ContractItem
         name="BasicAdapter"
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         address="0xAC23817f7E9Ec7EB6B7889BDd2b50e04a44470c5"
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renBTC"}
         erc20={"0xDBf31dF14B66535aF65AaC99C32e9eA844e14501"}
         gateway={"0x05Cadbf3128BcB7f2b89F3dD55E5B0a036a49e20"}
@@ -369,7 +369,7 @@ Currently, they are EVM-based contracts and Solana programs.
         decimals={8}
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renZEC"}
         erc20={"0x31a0D1A199631D244761EEba67e8501296d2E383"}
         gateway={"0x7986568375Af35B427f3f51389d73196967C356a"}
@@ -377,7 +377,7 @@ Currently, they are EVM-based contracts and Solana programs.
         decimals={8}
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renBCH"}
         erc20={"0xc3fEd6eB39178A541D274e6Fc748d48f0Ca01CC3"}
         gateway={"0x06A2C5d79c66268610eEBBca10AFa17092860830"}
@@ -385,7 +385,7 @@ Currently, they are EVM-based contracts and Solana programs.
         decimals={8}
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renFIL"}
         erc20={"0xc4Ace9278e7E01755B670C0838c3106367639962"}
         gateway={"0x4d59f628CB8e4670b779eAE22aF0c46DebC06695"}
@@ -393,7 +393,7 @@ Currently, they are EVM-based contracts and Solana programs.
         decimals={18}
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renDGB"}
         erc20={"0x2628568509E87c4429fBb5c664Ed11391BE1BD29"}
         gateway={"0x677b23D0ffc82414B063accA197f74d791285952"}
@@ -401,7 +401,7 @@ Currently, they are EVM-based contracts and Solana programs.
         decimals={8}
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renDOGE"}
         erc20={"0xcE829A89d4A55a63418bcC43F00145adef0eDB8E"}
         gateway={"0x9FB2C0b19A9fee6d02E7Ea861C71503608B64d6A"}
@@ -409,7 +409,7 @@ Currently, they are EVM-based contracts and Solana programs.
         decimals={8}
       />
       <AssetItem
-        link="https://explorer.matic.network/address/"
+        link="https://polygonscan.com/address/"
         symbol={"renLUNA"}
         erc20={"0x7c7DAAF2dB46fEFd067f002a69FD0BE14AeB159f"}
         gateway={"0x731Ea4Ba77fF184d89dBeB160A0078274Acbe9D2"}


### PR DESCRIPTION
changed links to reflect Polygon's new block scanner so matic links were turned to: https://polygonscan.com/address/