### PR TITLE
Fix broken links to RenVM and Darknode stats under 'APIs'

### DIFF
--- a/stats/about.mdx
+++ b/stats/about.mdx
@@ -16,8 +16,8 @@ Statistics about RenVM's volume and locked values can be found on the Command Ce
 
 ### APIs
 
-- [RenVM Stats](./stats/renvm-stats) - query current and historic information about RenVM volume and locked value
-- [Darknode Stats](./stats/darknode-stats) - query current and historic information about darknode registrations
+- [RenVM Stats](./renvm-stats) - query current and historic information about RenVM volume and locked value
+- [Darknode Stats](./darknode-stats) - query current and historic information about darknode registrations
 
 <hr />
 


### PR DESCRIPTION
Currently the links under 'APIs' go to:

https://renproject.github.io/ren-client-docs/stats/stats/renvm-stats
https://renproject.github.io/ren-client-docs/stats/stats/darknode-stats

which are not valid links, so this proposed change fixes that.