### PR TITLE
Fix Quick start and Tutorial links

### DIFF
--- a/ren-js/welcome.mdx
+++ b/ren-js/welcome.mdx
@@ -11,8 +11,8 @@ Welcome to the RenJS docs. If you are just starting out, start by jumping into t
 
 Integrate using the official RenVM JavaScript SDK, [RenJS](https://github.com/renproject/ren-js/), to provide native BTC support to your decentralized app. To get started with RenJS, read through the Tutorial, go through the Quick Start page or browse through the type docs.
 
--   [Quick start](./v3/quick-start)
--   [Tutorial](./v3/tutorial)
+-   [Quick start](./ren-js/v3/quick-start)
+-   [Tutorial](./ren-js/v3/tutorial)
 -   [RenJS Typedoc Reference](https://renproject.github.io/ren-js-v3-docs/) (automatically generated)
 
 <hr />


### PR DESCRIPTION
Fix Quick start and Tutorial links that currently are broken, because they omit /ren-js/ in the URL