### PR TITLE
Update gateway contracts

### DIFF
--- a/components/RenderGatewaySolConfig.tsx
+++ b/components/RenderGatewaySolConfig.tsx
@@ -156,6 +156,14 @@ const links = {
         Mainnet: "https://optimistic.etherscan.io/address/",
         Testnet: "https://kovan-optimistic.etherscan.io/address/",
     },
+    Kava: {
+        Mainnet: "https://explorer.kava.io/address/",
+        Testnet: "https://explorer.evm-alpha.kava.io/address/",
+    },
+    Moonbeam: {
+        Mainnet: "https://moonscan.io/address/",
+        Testnet: "https://moonbase.moonscan.io/address/",
+    },
     Solana: {
         Mainnet: "https://explorer.solana.com/address/",
         Testnet: "",

--- a/contracts/deployments.mdx
+++ b/contracts/deployments.mdx
@@ -79,6 +79,8 @@ export const GatewayContracts = () => {
                         <option>Avalanche</option>
                         <option>Arbitrum</option>
                         <option>Optimism</option>
+                        <option>Kava</option>
+                        <option>Moonbeam</option>
                         <option>Solana</option>
                     </select>
                     <div className="select_arrow" />


### PR DESCRIPTION
Update the docs to use gateway-sol v2.0.6 and add support for Kava and Moonbeam contracts.